### PR TITLE
fix BufLeave (broke exiting from CtrlP)

### DIFF
--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -104,4 +104,4 @@ endfunction
 autocmd BufEnter * if &buftype == 'terminal' | call feedkeys("\<C-W>N")  | endif
 
 " Switch back to terminal mode when exiting
-autocmd BufLeave * if &buftype == 'terminal' | silent! normal! i  | endif
+autocmd BufLeave * if &buftype == 'terminal' | execute "silent! normal! i"  | endif


### PR DESCRIPTION
Although `normal! i` in BufLeave should run in terminal buffers only it somehow breaks CtrlP and maybe other plugins in a way that its window could not easily be closed again. Leader mappings didn't work either after CtrlP stranded this way.

Replacing `normal! i` with `startinsert` or `feedkeys` doesn't work and operates on the next buffer entered instead of the one about to be left. Wrapping it as `execute "normal! i"` fixed the issue.