### PR TITLE
Add Clojure support, filetype recognition, customization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,8 @@ The activating commands are
 - maple ``:Imaple``
 - bash ``:Ibash``
 - zsh ``:Izsh``
+- clojure ``:Iclojure``
+- autodetect based on filetype ``:Iterm``
 
 Commands may be sent from a text file to the chosen terminal using
 ``CTRL-S``.
@@ -132,6 +134,33 @@ Supported terminals
 -  ``:Imaple`` Activate a maple terminal
 -  ``:Ibash`` Activate a bash terminal
 -  ``:Izsh`` Activate a zsh terminal
+-  ``:Iclojure`` Activate a clojure terminal
+-  ``:Iterm`` Activate default terminal for this filetype
+
+You can easily add your interpreter to Vimteractive, usign following code in your ``.vimrc``:
+
+.. code:: vim
+
+    " Mapping from Vimterpreter command to shell command
+    " This would give you :Iasyncpython command
+    let g:vimteractive_commands = {
+        \ 'asyncpython': 'python3 -m asyncio'
+        \ }
+
+    " If you see strange symbols like ^[[200~ when sending lines
+    " to your new interpreter, disable bracketed paste for it
+    " It's not needed for python3 -m asyncio, code below is only
+    " an example.
+    let g:vimteractive_bracketed_paste = {
+        \ 'asyncpython': 0
+        \ }
+
+    " If you want to set interpreter as default (used by :Iterm),
+    " map filetype to it. If not set, :Iterm will use interpreter
+    " named same with filetype.
+    let g:vimteractive_default_shells = {
+        \ 'python': 'asyncpython'
+        \ }
 
 Sending commands
 ~~~~~~~~~~~~~~~~
@@ -154,11 +183,7 @@ Extending functionality
 -----------------------
 
 This project is very much in an alpha phase, so if you have any issues
-that arise on your system, feel free to `leave an issue <https://github.com/williamjameshandley/vimteractive/issues/new>`__.
-
-If you want to add additional interpreters, in many cases, you simply
-need to add an extra ``I<interpreter name>`` command to
-``plugin/vimteractive.vim``. Feel free to create a `fork and pull
+that arise on your system, feel free to `leave an issue <https://github.com/williamjameshandley/vimteractive/issues/new>`__ or create a `fork and pull
 request <https://gist.github.com/Chaser324/ce0505fbed06b947d962>`__ with
 your proposed changes
 

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -1,0 +1,66 @@
+" Send list of lines to the terminal buffer, surrounded with a bracketed paste
+function! vimteractive#sendlines(lines)
+	if get(g:vimteractive_bracketed_paste, g:current_term_type, 1)
+		call term_sendkeys(g:vimteractive_buffer_name,"[200~" . join(a:lines, "\n") . "[201~\n")
+	else
+		call term_sendkeys(g:vimteractive_buffer_name, join(a:lines, "\n") . "\n")
+	endif
+endfunction
+
+" Send a line to the terminal buffer
+function! vimteractive#sendline(line)
+	call vimteractive#sendlines([a:line])
+endfunction
+
+" Start a vimteractive session
+function! vimteractive#session(terminal_type)
+
+    if has('terminal') == 0
+        echoerr "Your version of vim is not compiled with +terminal. Cannot use vimteractive"
+        return
+    endif
+
+	if a:terminal_type == '-auto-'
+		let term_type = get(g:vimteractive_default_shells, &filetype, &filetype)
+		if has_key(g:vimteractive_commands, term_type)
+			let l:terminal = get(g:vimteractive_commands, term_type)
+			let g:current_term_type = term_type
+		else
+			echoerr "Cannot determine terminal commmand for filetype " . &filetype
+			return
+		endif
+	else
+		let l:terminal = get(g:vimteractive_commands, a:terminal_type)
+		let g:current_term_type = a:terminal_type
+	endif
+
+    if g:vimteractive_terminal != '' && g:vimteractive_terminal != l:terminal
+        echoerr "Cannot run: " . l:terminal " Alreading running: " . g:vimteractive_terminal
+        return
+    endif
+
+    if bufnr(g:vimteractive_buffer_name) == -1
+        " If no vimteractive buffer exists:
+        " Start the terminal
+        let job = term_start(l:terminal, {"term_name":g:vimteractive_buffer_name})
+        set nobuflisted                          " Unlist the buffer
+        set norelativenumber                     " Turn off line numbering if off
+        set nonumber                             " Turn off line numbering if off
+        wincmd p                                 " Return to the previous window
+        let g:vimteractive_terminal = l:terminal " Name the current terminal
+
+    elseif bufwinnr(g:vimteractive_buffer_name) == -1
+        " Else if vimteractive buffer not open:
+        " Split the window
+        split
+        " switch the top window to the vimteractive buffer
+        execute ":b " . g:vimteractive_buffer_name
+        " Return to the previous window
+        wincmd p
+
+    else
+        " Else if throw error
+        echoerr "vimteractive already open. Quit before opening a new buffer"
+    endif
+endfunction
+

--- a/doc/vimteractive.txt
+++ b/doc/vimteractive.txt
@@ -48,7 +48,7 @@ a terminal command to freeze the output. You can disable this by putting
 
 stty -ixon
 
-into your shell config file
+into your .bashrc
 
 ------------------------------------------------------------------------------
 Example usage:
@@ -83,14 +83,14 @@ you wish to a new file if it contains valuable output
 
 
 Supported terminals                                   *vimteractive-terminals*
-*:Iipython* Activate an ipython terminal
-*:Ipython*  Activate a python terminal
-*:Ijulia*   Activate a julia terminal
-*:Imaple*   Activate a maple terminal
-*:Ibash*    Activate a bash terminal
-*:Izsh*     Activate a zsh terminal
-*:Iclojure*	Activate a clojure terminal
-*:Iterm*	Activate a terminal based on current filetype
+*:Iipython* 	Activate an ipython terminal
+*:Ipython*  	Activate a python terminal
+*:Ijulia*   	Activate a julia terminal
+*:Imaple*   	Activate a maple terminal
+*:Ibash*    	Activate a bash terminal
+*:Izsh*     	Activate a zsh terminal
+*:Iclojure*		Activate a clojure terminal
+*:Iterm*		Activate a terminal based on current filetype
 
 Sending commands                                                    *v_CTRL_S*
 
@@ -115,8 +115,7 @@ g:vimteractive_commands variable. For example:
 	let g:vimteractive_commands = { 'pythonasync': 'python -m asyncio' }
 
 will provide you :Ipythonasync command starting Python 3.8+ asyncio REPL.
-If you want to make this command default (used by |:Iterm|) for python
-filetype, you should do
+If you want to make this command default for python filetype, you should do
 
 	let g:vimteractive_default_shells = { 'python': 'pythonasync' }
 

--- a/doc/vimteractive.txt
+++ b/doc/vimteractive.txt
@@ -115,7 +115,7 @@ g:vimteractive_commands variable. For example:
 	let g:vimteractive_commands = { 'pythonasync': 'python -m asyncio' }
 
 will provide you :Ipythonasync command starting Python 3.8+ asyncio REPL.
-If you want to make this command default (used by *:Iterm*) for python
+If you want to make this command default (used by |:Iterm|) for python
 filetype, you should do
 
 	let g:vimteractive_default_shells = { 'python': 'pythonasync' }

--- a/doc/vimteractive.txt
+++ b/doc/vimteractive.txt
@@ -28,7 +28,10 @@ The activating commands are
 - julia   |:Ijulia|
 - maple   |:Imaple|
 - bash    |:Ibash|
+- clojure |:Iclojure|
 - zsh     |:Izsh|
+
+You can also let Vimteractive detect interpreter using |:Iterm|
 
 Commands may be sent from a text file to the chosen terminal using CTRL-S. 
 See |v_CTRL_S| for more details.
@@ -45,7 +48,7 @@ a terminal command to freeze the output. You can disable this by putting
 
 stty -ixon
 
-into your .bashrc
+into your shell config file
 
 ------------------------------------------------------------------------------
 Example usage:
@@ -86,6 +89,8 @@ Supported terminals                                   *vimteractive-terminals*
 *:Imaple*   Activate a maple terminal
 *:Ibash*    Activate a bash terminal
 *:Izsh*     Activate a zsh terminal
+*:Iclojure*	Activate a clojure terminal
+*:Iterm*	Activate a terminal based on current filetype
 
 Sending commands                                                    *v_CTRL_S*
 
@@ -104,14 +109,26 @@ ALT-S sends all lines from the start to the current line.
 ==============================================================================
 3. Extending functionality                            *vimteractive-extending*
 
+To add a new interpreter to Vimteractive, you should define
+g:vimteractive_commands variable. For example:
+
+	let g:vimteractive_commands = { 'pythonasync': 'python -m asyncio' }
+
+will provide you :Ipythonasync command starting Python 3.8+ asyncio REPL.
+If you want to make this command default (used by *:Iterm*) for python
+filetype, you should do
+
+	let g:vimteractive_default_shells = { 'python': 'pythonasync' }
+
+If you see escape sequences appearing when you do CTRL-S for your interpreter,
+you may try to disable bracketed paste mode for it:
+
+	let g:vimteractive_bracketed_paste = { 'pythonasync': 0 }
+
 This project is very much in an alpha phase, so if you have any issues that
 arise on your system, feel free to contact me:
 
     williamjameshandley@gmail.com.
-
-In many cases, you simply need to add an extra I<interpreter name> command to
-plugin/vimteractive.vim
-
 
 ==============================================================================
 4. About                                          *vimteractive-functionality*

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -20,6 +20,7 @@ let g:vimteractive_bash_command = 'bash'
 let g:vimteractive_zsh_command = 'zsh'
 let g:vimteractive_julia_command = 'julia'
 let g:vimteractive_maple_command = 'maple -c "interface(errorcursor=false);"'
+let g:vimteractive_clojure_command = 'clojure'
 
 " User commands
 " =============
@@ -31,6 +32,7 @@ command!  Ibash    :call Vimteractive_session(g:vimteractive_bash_command)
 command!  Izsh     :call Vimteractive_session(g:vimteractive_zsh_command)
 command!  Ijulia   :call Vimteractive_session(g:vimteractive_julia_command)
 command!  Imaple   :call Vimteractive_session(g:vimteractive_maple_command)
+command!  Iclojure :call Vimteractive_session(g:vimteractive_clojure_command)
 
 " Control-S in normal mode to send current line
 noremap  <silent> <C-s>      :call Vimteractive_sendline(getline('.'))<CR>

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -41,6 +41,7 @@ let g:vimteractive_bracketed_paste = {
 if !has_key(g:, 'vimteractive_loaded')
 	let g:vimteractive_loaded = 1
 
+	" Building :I* commands (like :Ipython, :Iipython and so)
 	for term_type in keys(g:vimteractive_commands)
 		execute 'command! I' . term_type . " :call vimteractive#session('" . term_type . "')"
 	endfor


### PR DESCRIPTION
- Move most of logic to `autoload/`
- Easy interpreters customization with config vars
- Add ability to opt out from bracketed paste
- Built-in Clojure support
- `:Iterm` spawning default terminal for filetype. Resolves #6.