### PR TITLE
Setting default value for bufname

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Vimteractive
 ============
 :vimteractive: send commands from text files to interactive programs via vim 
 :Author: Will Handley
-:Version: 2.0.1
+:Version: 2.0.2
 :Homepage: https://github.com/williamjameshandley/vimteractive
 :Documentation: ``:help vimteractive``
 

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -168,15 +168,20 @@ endfunction
 
 
 " Connect to vimteractive terminal
-function! vimteractive#connect(bufname)
+function! vimteractive#connect(...)
+    " Check if there was an argument passed to this function
+    if len(a:000) == 0
+        let l:bufname = ''
+    else
+        let l:bufname = a:0[0]
+    endif
     if len(s:vimteractive_buffers) == 0
         echoerr "No vimteractive terminal buffers present"
         echoerr "call :Iterm to start a new one"
         return
     endif
-
-    let l:bufname = a:bufname
-    if strlen(a:bufname) ==# 0
+    " Check if bufname isn't just ''
+    if strlen(l:bufname) ==# 0
         if len(s:vimteractive_buffers) ==# 1
             let l:bufname = vimteractive#buffer_list()[0] 
         else

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -169,19 +169,22 @@ endfunction
 
 " Connect to vimteractive terminal
 function! vimteractive#connect(...)
-    " Check if there was an argument passed to this function
-    if len(a:000) == 0
-        let l:bufname = ''
-    else
-        let l:bufname = a:0[0]
-    endif
+    " Check that there are buffers to connect to
     if len(s:vimteractive_buffers) == 0
         echoerr "No vimteractive terminal buffers present"
         echoerr "call :Iterm to start a new one"
         return
     endif
+
+    " Check if there was an argument passed to this function
+    if a:0 == 0
+        let l:bufname = ''
+    else
+        let l:bufname = a:1
+    endif
+
     " Check if bufname isn't just ''
-    if strlen(l:bufname) ==# 0
+    if l:bufname == ''
         if len(s:vimteractive_buffers) ==# 1
             let l:bufname = vimteractive#buffer_list()[0] 
         else


### PR DESCRIPTION
- Modified the `vimteractive#connect()` function to take one or more optional arguments
- If an argument is given, set `bufname` to that
- Otherwise, set `bufname = ''`

My hope is that this will work across different versions of vim, so we don't have to do a check for the vim version.