### PR TITLE
Send only visually selected text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Vimteractive
 ============
 :vimteractive: send commands from text files to interactive programs via vim 
 :Author: Will Handley
-:Version: 2.0.2
+:Version: 2.1.0
 :Homepage: https://github.com/williamjameshandley/vimteractive
 :Documentation: ``:help vimteractive``
 
@@ -156,8 +156,7 @@ cursor the terminal.
 In Insert mode, ``CTRL-S`` sends the line currently being edited, and
 then returns to insert mode at the same location.
 
-In Visual mode, ``CTRL-S`` sends all currently selected lines to the
-terminal.
+In Visual mode, ``CTRL-S`` sends the current selection to the terminal.
 
 ``ALT-S`` sends all lines from the start to the current line.
 
@@ -219,6 +218,7 @@ Similar projects
 
 Changelist
 ----------
+:v2.1: `Visual selection improvement <https://github.com/williamjameshandley/vimteractive/pull/15>`__
 :v2.0: `Multiple terminal functionality <https://github.com/williamjameshandley/vimteractive/pull/9>`__
 :v1.7: `Autodetection of terminals <https://github.com/williamjameshandley/vimteractive/pull/5>`__
 :v1.6: CtrlP `bugfix <https://github.com/williamjameshandley/vimteractive/pull/4>`__

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -89,9 +89,9 @@ function! vimteractive#sendlines(lines)
     
     mark`
     if get(g:vimteractive_bracketed_paste, l:term_type, 1)
-        call term_sendkeys(b:vimteractive_connected_term,"[200~" . join(a:lines, "\n") . "[201~\n")
+        call term_sendkeys(b:vimteractive_connected_term,"[200~" . a:lines . "[201~\n")
     else
-        call term_sendkeys(b:vimteractive_connected_term, join(a:lines, "\n") . "\n")
+        call term_sendkeys(b:vimteractive_connected_term, a:lines . "\n")
     endif
 endfunction
 

--- a/doc/vimteractive.txt
+++ b/doc/vimteractive.txt
@@ -19,14 +19,12 @@ Vimteractive was inspired by the workflow of the vim-ipython plugin:
 
     https://github.com/ivanov/vim-ipython
 
-This plugin is designed to extend a subset of the functionality of vimteractive
-to other interpreters (including ipython). This plugin is designed to extend a
-subset of the functionality of vim-ipython to other interpreters (including
-ipython). It is based around the unix philosophy of "do one thing and do it
-well".  It aims to provide a robust and simple link between text files and
-interactive interpreters. Vimteractive will never aim to do things like
-autocompletion, leaving that to other, more developed tools such as
-YouCompleteMe.
+This plugin is designed to extend a subset of the functionality of vim-ipython
+to other interpreters (including ipython). It is based around the unix
+philosophy of "do one thing and do it well".  It aims to provide a robust and
+simple link between text files and interactive interpreters. Vimteractive will
+never aim to do things like autocompletion, leaving that to other, more
+developed tools such as YouCompleteMe.
 
 The activating commands are 
 - ipython |:Iipython| 
@@ -121,7 +119,7 @@ the terminal.
 In |Insert-mode|, CTRL-S sends the line currently being edited, and then
 returns to insert mode at the same location.
 
-In |Visual-mode|, CTRL-S sends all currently selected lines to the terminal.
+In |Visual-mode|, CTRL-S sends the current selection to the terminal.
 
 ALT-S sends all lines from the start to the current line.
 
@@ -132,7 +130,7 @@ create one for you using |:Iterm|.
 3. Connecting to existing REPLs             *:Iconn* *vimteractive-connecting*
 :Iconn [{buffer}]	Connect current buffer to REPL in {buffer}. You can
 					connect any number of buffers to one REPL. {buffer}
-					can be omited if there is only one terminal.
+					can be omitted if there is only one terminal.
 
 ==============================================================================
 4. Extending functionality                            *vimteractive-extending*

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -72,13 +72,13 @@ endif
 " ===================
 
 " Control-S in normal mode to send current line
-noremap  <silent> <C-s>      :call vimteractive#sendlines([getline('.')])<CR>
+noremap  <silent> <C-s>      :call vimteractive#sendlines(getline('.'))<CR>
 
 " Control-S in insert mode to send current line
-inoremap <silent> <C-s> <Esc>:call vimteractive#sendlines([getline('.')])<CR>a
+inoremap <silent> <C-s> <Esc>:call vimteractive#sendlines(getline('.'))<CR>a
 
 " Control-S in visual mode to send multiple lines
-vnoremap <silent> <C-s> <Esc>:call vimteractive#sendlines(getline("'<","'>"))<CR>
+vnoremap <silent> <C-s> <Esc>:call vimteractive#sendlines(getreg('*'))<CR>
 
 " Alt-S in normal mode to send all lines up to this point
-noremap <silent> <A-s> :call vimteractive#sendlines(getline(1,'.'))<CR>
+noremap <silent> <A-s> :call vimteractive#sendlines(join(getline(1,'.'), "\n"))<CR>


### PR DESCRIPTION
When one selects visual text and presses control-S, currently the entire line is sent.

This update means that only the selected text is sent.

Procedurally this was an extremely minor change, changing `getline("'<","'>")` to `getreg('*')`. 

This also neatens up `vimteractive#sendlines` so that it now expects a string, not a list of strings.

Resolves #14