### PR TITLE
Fixing visual mode and bracketed paste

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,46 +3,49 @@ Vimteractive
 ============
 :vimteractive: send commands from text files to interactive programs via vim 
 :Author: Will Handley
-:Version: 2.2.0
+:Version: 2.2.1
 :Homepage: https://github.com/williamjameshandley/vimteractive
 :Documentation: ``:help vimteractive``
 
 Vimteractive was inspired by the workflow of the
 `vim-ipython <https://github.com/ivanov/vim-ipython>`__ plugin.
 
-This plugin is designed to extend a subset of the functionality of
-vim-ipython to other interpreters (including ipython). It is based
-around the unix philosophy of `"do one thing and do it
-well" <https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well>`__.
+This plugin is designed to extend a subset of the functionality of vim-ipython
+to other interpreters (including ipython). It is based around the unix
+philosophy of `"do one thing and do it well" <https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well>`__. 
 Vimteractive aims to provide a robust and simple link between text files and
 interactive interpreters. Vimteractive will never aim to do things like
 autocompletion, leaving that to other, more developed tools such as
-`YouCompleteMe <https://github.com/Valloric/YouCompleteMe>`__.
+`YouCompleteMe <https://github.com/Valloric/YouCompleteMe>`__ or
+`TabNine <https://tabnine.com>``.
 
 The activating commands are
 
 - ipython ``:Iipython``
-- python ``:Ipython``
 - julia ``:Ijulia``
 - maple ``:Imaple``
 - bash ``:Ibash``
 - zsh ``:Izsh``
+- python ``:Ipython``
 - clojure ``:Iclojure``
 - autodetect based on filetype ``:Iterm``
 
-Commands may be sent from a text file to the chosen terminal using
-``CTRL-S``. If there is no terminal, ``CTRL-S`` will automatically
-open one for you using ``:Iterm``.
+Commands may be sent from a text file to the chosen terminal using ``CTRL-S``.
+If there is no terminal, ``CTRL-S`` will automatically open one for you using
+``:Iterm``.
 
-It's highly recommended to set your default Python shell to IPython
-(see "Extending functionality" section for instructions). If you prefer
-not to do it, make sure, that every top-level block has at least one newline
-after it.
+Note: it's highly recommended to use IPython as your default Python
+interpreter. You can set it like this:
+
+.. code:: vim
+
+	let g:vimteractive_default_shells = { 'python': 'ipython' }
 
 Installation
 ------------
 
-Since this package leverages the native vim interactive terminal, vimteractive is only compatible with vim 8 or greater.
+Since this package leverages the native vim interactive terminal, vimteractive
+is only compatible with vim 8 or greater.
 
 To use the key-bindings, you should first disable the ``CTRL-S``
 default, which is a terminal command to freeze the output. You can
@@ -71,22 +74,21 @@ Motivation
 ----------
 
 `IPython and Jupyter <https://ipython.org/>`__ are excellent tools for
-exploratory analyses in python. They leverage the interactivity of the
-python kernel to allow you to keep results of calculations in memory
-whilst developing further code to process them.
+exploratory analyses in python. They leverage the interactivity of the python
+kernel to allow you to keep results of calculations in memory whilst developing
+further code to process them.
 
-However, I can't stand typing into anything other than vim. Anywhere
-else, my screen fills with hjklEB, or worse, I close the window with a
-careless ``<C-w>``. I want a technique that allows me to operate on
-plain text files, but still be able to work interactively with the
-interpreter with minimal effort.
+However, I can't stand typing into anything other than vim. Anywhere else, my
+screen fills with hjklEB, or worse, I close the window with a careless
+``<C-w>``. I want a technique that allows me to operate on plain text files,
+but still be able to work interactively with the interpreter with minimal
+effort.
 
-`Many Projects <#similar-projects>`__ achieve this with a varying level
-of functionality. Vimteractive aims to create the simplest tool for
-sending things from text to interpreter, and making it easy to add
-additional interpreters. In particular, my main aim in starting this was
-to get a vim-ipython like interface to the command line
-`maple <https://www.maplesoft.com/>`__.
+`Many Projects <#similar-projects>`__ achieve this with a varying level of
+functionality. Vimteractive aims to create the simplest tool for sending things
+from text to interpreter, and making it easy to add additional interpreters. In
+particular, my main aim in starting this was to get a vim-ipython like
+interface to the command line `maple <https://www.maplesoft.com/>`__.
 
 Usage
 -----
@@ -110,69 +112,91 @@ Create a python file ``test.py`` with the following content:
    ax.set_xlabel('$x$')
    ax.set_ylabel('$y$')
 
-Now start an ipython interpreter in vim with ``:Iipython``. You should
-see a preview window open above with your ipython prompt. Position your
-cursor over the first line of ``test.py``, and press
-``CTRL-S``. You should see this line now appear in the first prompt of
-the preview window. Do the same with the second and fourth lines. At the
-fourth line, you should see a figure appear once it's constructed with
-``plt.subplots()``. Continue by sending lines to the interpreter. You
-can send multiple lines by doing a visual selection and pressing
-``CTRL-S``.
+Now start an ipython interpreter in vim with ``:Iipython``. You should see a
+preview window open above with your ipython prompt. Position your cursor over
+the first line of ``test.py``, and press ``CTRL-S``. You should see this line
+now appear in the first prompt of the preview window. Do the same with the
+second and fourth lines. At the fourth line, you should see a figure appear
+once it's constructed with ``plt.subplots()``. Continue by sending lines to the
+interpreter. You can send multiple lines by doing a visual selection and
+pressing ``CTRL-S``.
 
-If you switch windows with ``CTRL-W+k``, you will see the terminal
-buffer switch to a more usual looking normal-mode buffer, from which you
-can perform traditional normal mode commands. However, if you try to
-insert, you will enter the terminal, and be able to enter commands
-interactively into the prompt as if you had run it in the command line.
-You can save this buffer if you wish to a new file if it contains
-valuable output
+If you switch windows with ``CTRL-W+k``, you will see the terminal buffer
+switch to a more usual looking normal-mode buffer, from which you can perform
+traditional normal mode commands. However, if you try to insert, you will enter
+the terminal, and be able to enter commands interactively into the prompt as if
+you had run it in the command line.  You can save this buffer if you wish to a
+new file if it contains valuable output
 
 You may want to send lines to one terminal from two buffers. To achieve that,
 run ``:Iconn <buffer_name>`` where ``<buffer_name>`` is a name of buffer
-containing terminal. If there is only one terminal, you can use just ``:Iconn``.
+containing terminal. If there is only one terminal, you can use just
+``:Iconn``.
 
 Supported terminals
 ~~~~~~~~~~~~~~~~~~~
 
 -  ``:Iipython`` Activate an ipython terminal
--  ``:Ipython`` Activate a python terminal
 -  ``:Ijulia`` Activate a julia terminal
 -  ``:Imaple`` Activate a maple terminal
 -  ``:Ibash`` Activate a bash terminal
 -  ``:Izsh`` Activate a zsh terminal
+-  ``:Ipython`` Activate a python terminal
 -  ``:Iclojure`` Activate a clojure terminal
 -  ``:Iterm`` Activate default terminal for this filetype
 
 Sending commands
 ~~~~~~~~~~~~~~~~
 
-``CTRL-S`` sends lines of text to the interpreter in a mode-dependent
-manner:
+``CTRL-S`` sends lines of text to the interpreter in a mode-dependent manner:
 
-In Normal mode, ``CTRL-S`` sends the line currently occupied by the
-cursor the terminal.
+In Normal mode, ``CTRL-S`` sends the line currently occupied by the cursor the
+terminal.
 
-In Insert mode, ``CTRL-S`` sends the line currently being edited, and
-then returns to insert mode at the same location.
+In Insert mode, ``CTRL-S`` sends the line currently being edited, and then
+returns to insert mode at the same location.
 
 In Visual mode, ``CTRL-S`` sends the current selection to the terminal.
 
 ``ALT-S`` sends all lines from the start to the current line.
 
+Connecting to an existing terminal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``:Iconn [{buffer]`` connects current buffer to REPL in ``{buffer}``. You can
+connect any number of buffers to one REPL. ``{buffer}`` can be omitted if there
+is only one terminal.
+
+
+Common issues
+-------------
+
+Bracketed paste
+~~~~~~~~~~~~~~~
+
+If you see strange symbols like ``^[[200~`` when sending lines to your new
+interpreter, you may be on an older system which does not have bracketed paste
+enabled, or have other shell misbehaviour issues. You can change the default
+setting with 
+
+.. code:: vim
+
+	let g:vimteractive_bracketed_paste_default = 0
+
+
 Options
-~~~~~~~
+-------
 These options can be put in your ``.vimrc``, or run manually as desired:
 
 .. code:: vim
 
-    let g:vimteractive_vertical = 1  " Vertically split terminals
-    let g:vimteractive_autostart = 0 " Don't start terminals by default
+    let g:vimteractive_vertical = 1        " Vertically split terminals
+    let g:vimteractive_autostart = 0       " Don't start terminals by default
 
 Extending functionality
 -----------------------
 
-This project is very much in an alpha phase, so if you have any issues
+This project is very much in an beta phase, so if you have any issues
 that arise on your system, feel free to `leave an issue <https://github.com/williamjameshandley/vimteractive/issues/new>`__ or create a `fork and pull
 request <https://gist.github.com/Chaser324/ce0505fbed06b947d962>`__ with
 your proposed changes

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -85,10 +85,10 @@ function! vimteractive#sendlines(lines)
 
     call s:show_term()
 
-    let l:term_type = getbufvar(b:vimteractive_connected_term, "term_type")
+    let l:term_type = getbufvar(b:vimteractive_connected_term, "vimteractive_term_type")
     
     mark`
-    if get(g:vimteractive_bracketed_paste, l:term_type, 1)
+    if get(g:vimteractive_bracketed_paste, l:term_type, 0)
         call term_sendkeys(b:vimteractive_connected_term,"[200~" . a:lines . "[201~\n")
     else
         call term_sendkeys(b:vimteractive_connected_term, a:lines . "\n")

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -87,7 +87,6 @@ function! vimteractive#sendlines(lines)
 
     let l:term_type = getbufvar(b:vimteractive_connected_term, "vimteractive_term_type")
     
-    mark`
     if get(g:vimteractive_bracketed_paste, l:term_type, 1)
         call term_sendkeys(b:vimteractive_connected_term,"[200~" . a:lines . "[201~\n")
     else

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -87,7 +87,7 @@ function! vimteractive#sendlines(lines)
 
     let l:term_type = getbufvar(b:vimteractive_connected_term, "vimteractive_term_type")
     
-    if get(g:vimteractive_bracketed_paste, l:term_type, 1)
+    if get(g:vimteractive_bracketed_paste, l:term_type, g:vimteractive_bracketed_paste_default)
         call term_sendkeys(b:vimteractive_connected_term,"[200~" . a:lines . "[201~\n")
     else
         call term_sendkeys(b:vimteractive_connected_term, a:lines . "\n")

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -88,7 +88,7 @@ function! vimteractive#sendlines(lines)
     let l:term_type = getbufvar(b:vimteractive_connected_term, "vimteractive_term_type")
     
     mark`
-    if get(g:vimteractive_bracketed_paste, l:term_type, 0)
+    if get(g:vimteractive_bracketed_paste, l:term_type, 1)
         call term_sendkeys(b:vimteractive_connected_term,"[200~" . a:lines . "[201~\n")
     else
         call term_sendkeys(b:vimteractive_connected_term, a:lines . "\n")

--- a/doc/vimteractive.txt
+++ b/doc/vimteractive.txt
@@ -8,9 +8,10 @@ CONTENTS                                               *vimteractive-contents*
 
     1.Intro........................................|vimteractive-intro|
     2.Usage........................................|vimteractive-usage|
-    3.Extending functionality......................|vimteractive-extending|
-    4.About........................................|vimteractive-about|
-    5.License......................................|vimteractive-license|
+    3.Common issues................................|vimteractive-issues|
+    4.Extending functionality......................|vimteractive-extending|
+    5.About........................................|vimteractive-about|
+    6.License......................................|vimteractive-license|
 
 ==============================================================================
 1. Intro                                                  *vimteractive-intro*
@@ -24,34 +25,29 @@ to other interpreters (including ipython). It is based around the unix
 philosophy of "do one thing and do it well".  It aims to provide a robust and
 simple link between text files and interactive interpreters. Vimteractive will
 never aim to do things like autocompletion, leaving that to other, more
-developed tools such as YouCompleteMe.
+developed tools such as YouCompleteMe or TabNine.
 
 The activating commands are 
 - ipython |:Iipython| 
-- python  |:Ipython| 
 - julia   |:Ijulia|
 - maple   |:Imaple|
 - bash    |:Ibash|
-- clojure |:Iclojure|
 - zsh     |:Izsh|
+- python  |:Ipython| 
+- clojure |:Iclojure|
+- autodetect based on filetype |:Iterm| 
 
-You can also let Vimteractive detect interpreter using |:Iterm| or just send
-some lines: Vimteractive will create terminal if needed. Note: it's highly
-recommended to use IPython as your default Python interpreter. You can set it
-like this:
+Commands may be sent from a text file to the chosen terminal using CTRL-S. If
+there is no terminal, CTRL-S will automatically open one for you using
+|:Iterm|.  See |v_CTRL_S| for more details.
+
+Note: it's highly recommended to use IPython as your default Python
+interpreter. You can set it like this:
 
 	let g:vimteractive_default_shells = { 'python': 'ipython' }
 
-Default Python REPL support for pasting is really bad and you should use
-IPython whenever possible. If you need to use default Python REPL, you must
-put newline after every top-level block.
-
-Commands may be sent from a text file to the chosen terminal using CTRL-S. 
-See |v_CTRL_S| for more details.
-
 Since this package leverages the native vim interactive terminal, it is 
 only compatible with vim 8 or greater.
-
 
 ==============================================================================
 2. Usage                                                  *vimteractive-usage*
@@ -64,7 +60,7 @@ stty -ixon
 into your .bashrc (or equivalent shell profile file)
 
 ------------------------------------------------------------------------------
-Example usage:
+Example usage                                             *vimteractive-usage*
 
 Create a python file "test.py" with the following content:
 
@@ -97,18 +93,19 @@ you wish to a new file if it contains valuable output
 By default every buffer is connected to separate terminal. If you want to
 connect two buffers to one terminal, use |:Iconn| command.
 
-
+------------------------------------------------------------------------------
 Supported terminals                                   *vimteractive-terminals*
 
 *:Iipython* 	Activate an ipython terminal
-*:Ipython*  	Activate a python terminal
 *:Ijulia*   	Activate a julia terminal
 *:Imaple*   	Activate a maple terminal
 *:Ibash*    	Activate a bash terminal
 *:Izsh*     	Activate a zsh terminal
+*:Ipython*  	Activate a python terminal
 *:Iclojure*		Activate a clojure terminal
 *:Iterm*		Activate a terminal based on current filetype
 
+------------------------------------------------------------------------------
 Sending commands                                                    *v_CTRL_S*
 
 CTRL-S sends lines of text to the interpreter in a mode-dependent manner:
@@ -126,23 +123,38 @@ ALT-S sends all lines from the start to the current line.
 If there is no active terminal for current buffer, CTRL-S will automatically
 create one for you using |:Iterm|.
 
-==============================================================================
-3. Connecting to existing REPLs             *:Iconn* *vimteractive-connecting*
-:Iconn [{buffer}]	Connect current buffer to REPL in {buffer}. You can
-					connect any number of buffers to one REPL. {buffer}
-					can be omitted if there is only one terminal.
+------------------------------------------------------------------------------
+Connecting to existing REPLs                *:Iconn* *vimteractive-connecting*
+
+:Iconn [{buffer}] connects current buffer to REPL in {buffer}. You can connect
+any number of buffers to one REPL. {buffer} can be omitted if there is only one
+terminal.
 
 ==============================================================================
-3. Vimteractive options                                 *vimteractive-options*
+3. Common issues                                         *vimteractive-issues*
+
+------------------------------------------------------------------------------
+Bracketed paste                          *vimteractive-issues-bracketed-paste* 
+
+If you see strange symbols like ^[[200~ when sending lines to your new
+interpreter, you may be on an older system which does not have bracketed paste
+enabled, or have other shell misbehaviour issues. You can change the default
+setting with 
+
+	let g:vimteractive_bracketed_paste_default = 0
+
+
+==============================================================================
+4. Vimteractive options                                 *vimteractive-options*
 
 These options can be put in your |.vimrc|, or run manually as desired:
 
-    let g:vimteractive_vertical = 1  " Vertically split terminals
-    let g:vimteractive_autostart = 0 " Don't start terminals by default
+    let g:vimteractive_vertical = 1        " Vertically split terminals
+    let g:vimteractive_autostart = 0       " Don't start terminals by default
 
 
 ==============================================================================
-4. Extending functionality                            *vimteractive-extending*
+5. Extending functionality                            *vimteractive-extending*
 
 To add a new interpreter to Vimteractive, you should define
 g:vimteractive_commands variable. For example:
@@ -165,13 +177,13 @@ milliseconds like this:
 
 	let g:vimteractive_slow_prompt = { 'pythonasync': 200 }
 
-This project is very much in an alpha phase, so if you have any issues that
+This project is very much in an beta phase, so if you have any issues that
 arise on your system, feel free to contact me:
 
     williamjameshandley@gmail.com
 
 ==============================================================================
-5. About                                          *vimteractive-functionality*
+6. About                                          *vimteractive-functionality*
 
 The core maintainer of vimteractive is:
 
@@ -182,6 +194,6 @@ Find the latest version of vimteractive at:
     http://github.com/williamjameshandley/vimteractive
 
 ==============================================================================
-6. License                                              *vimteractive-license*
+7. License                                              *vimteractive-license*
 
 Vimteractive is licensed under GPL 3.0

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -43,6 +43,9 @@ if !has_key(g:, 'vimteractive_default_shells')
 endif
 
 " If 0, disable bracketed paste escape sequences
+if !has_key(g:, 'vimteractive_bracketed_paste_default') 
+    let g:vimteractive_bracketed_paste_default=1
+endif
 if !has_key(g:, 'vimteractive_bracketed_paste')
 	let g:vimteractive_bracketed_paste = { }
 endif

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -84,7 +84,7 @@ noremap  <silent> <C-s>      :call vimteractive#sendlines(getline('.'))<CR>
 inoremap <silent> <C-s> <Esc>:call vimteractive#sendlines(getline('.'))<CR>a
 
 " Control-S in visual mode to send multiple lines
-vnoremap <silent> <C-s> m`"xy:call vimteractive#sendlines(substitute(getreg('x'), "\n*$", "", ""))<CR>``
+vnoremap <silent> <C-s> m`""y:call vimteractive#sendlines(substitute(getreg('"'), "\n*$", "", ""))<CR>``
 
 " Alt-S in normal mode to send all lines up to this point
 noremap <silent> <A-s> :call vimteractive#sendlines(join(getline(1,'.'), "\n"))<CR>

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -84,7 +84,7 @@ noremap  <silent> <C-s>      :call vimteractive#sendlines(getline('.'))<CR>
 inoremap <silent> <C-s> <Esc>:call vimteractive#sendlines(getline('.'))<CR>a
 
 " Control-S in visual mode to send multiple lines
-vnoremap <silent> <C-s> <Esc>:call vimteractive#sendlines(getreg('*'))<CR>
+vnoremap <silent> <C-s> "xy<CR>:call vimteractive#sendlines(substitute(getreg('x'), "\n*$", "", ""))<CR>
 
 " Alt-S in normal mode to send all lines up to this point
 noremap <silent> <A-s> :call vimteractive#sendlines(join(getline(1,'.'), "\n"))<CR>

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -84,7 +84,7 @@ noremap  <silent> <C-s>      :call vimteractive#sendlines(getline('.'))<CR>
 inoremap <silent> <C-s> <Esc>:call vimteractive#sendlines(getline('.'))<CR>a
 
 " Control-S in visual mode to send multiple lines
-vnoremap <silent> <C-s> "xy<CR>:call vimteractive#sendlines(substitute(getreg('x'), "\n*$", "", ""))<CR>
+vnoremap <silent> <C-s> m`"xy:call vimteractive#sendlines(substitute(getreg('x'), "\n*$", "", ""))<CR>``
 
 " Alt-S in normal mode to send all lines up to this point
 noremap <silent> <A-s> :call vimteractive#sendlines(join(getline(1,'.'), "\n"))<CR>


### PR DESCRIPTION
Hi @williamjameshandley ,

Thanks for great plugin! I am suggesting a few changes / fixes. If you don't like them, happy to remove some of them - I changed it mainly because I needed all of these so the plugin works properly for me. What I changed:

- A bug in getting "term_type" buffer var - it should be called "vimteractive_term_type"
- Bracketed paste is fairly new feature and it is not available for instance in AWS Workspaces (because Amazon Linux is an older CentOS with bash 4.3 only), so I would rather have non-bracketed paste as default
- Visual mode sendlines relied on clipboard or xterm_clipboard features by accessing * register without actually putting the values into it. Again, these features are missing in many default installations (AWS Workspaces, WSL) - I suggest explicitly yanking the selection into x register and reading from it. Also, I am trimming one trailing newline, as there is another explicit <CR> being sent.

Up to you if you want to take all of these or just some.