### PR TITLE
Remove trailing whitespace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ============
 Vimteractive
 ============
-:vimteractive: send commands from text files to interactive programs via vim 
+:vimteractive: send commands from text files to interactive programs via vim
 :Author: Will Handley
 :Version: 2.3.1
 :Homepage: https://github.com/williamjameshandley/vimteractive
@@ -12,7 +12,7 @@ Vimteractive was inspired by the workflow of the
 
 This plugin is designed to extend a subset of the functionality of vim-ipython
 to other interpreters (including ipython). It is based around the unix
-philosophy of `"do one thing and do it well" <https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well>`__. 
+philosophy of `"do one thing and do it well" <https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well>`__.
 Vimteractive aims to provide a robust and simple link between text files and
 interactive interpreters. Vimteractive will never aim to do things like
 autocompletion, leaving that to other, more developed tools such as
@@ -58,7 +58,7 @@ disable this by putting
 
 into your ``.bashrc`` (or equivalent shell profile file).
 
-Installation should be relatively painless via 
+Installation should be relatively painless via
 `the usual routes <https://vimawesome.com/plugin/vimteractive>`_ such as
 `Vundle <https://github.com/VundleVim/Vundle.vim>`__,
 `Pathogen <https://github.com/tpope/vim-pathogen>`__ or the vim 8 native
@@ -179,7 +179,7 @@ Bracketed paste
 If you see strange symbols like ``^[[200~`` when sending lines to your new
 interpreter, you may be on an older system which does not have bracketed paste
 enabled, or have other shell misbehaviour issues. You can change the default
-setting with 
+setting with
 
 .. code:: vim
 

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -66,7 +66,7 @@ endfunction
 " Send list of lines to the terminal buffer, surrounded with a bracketed paste
 function! vimteractive#sendlines(lines)
     " Autostart a terminal if desired
-    if !exists("b:vimteractive_connected_term") 
+    if !exists("b:vimteractive_connected_term")
         if g:vimteractive_autostart
             call vimteractive#term_start('-auto-')
         else
@@ -86,7 +86,7 @@ function! vimteractive#sendlines(lines)
     call s:show_term()
 
     let l:term_type = getbufvar(b:vimteractive_connected_term, "vimteractive_term_type")
-    
+
     if get(g:vimteractive_bracketed_paste, l:term_type, g:vimteractive_bracketed_paste_default)
         call term_sendkeys(b:vimteractive_connected_term,"[200~" . a:lines . "[201~\n")
     else
@@ -187,7 +187,7 @@ function! vimteractive#connect(...)
     " Check if bufname isn't just ''
     if l:bufname == ''
         if len(s:vimteractive_buffers) ==# 1
-            let l:bufname = vimteractive#buffer_list()[0] 
+            let l:bufname = vimteractive#buffer_list()[0]
         else
             echom "Please specify terminal from "
             echom vimteractive#buffer_list()

--- a/doc/vimteractive.txt
+++ b/doc/vimteractive.txt
@@ -27,16 +27,16 @@ simple link between text files and interactive interpreters. Vimteractive will
 never aim to do things like autocompletion, leaving that to other, more
 developed tools such as YouCompleteMe or TabNine.
 
-The activating commands are 
-- ipython |:Iipython| 
+The activating commands are
+- ipython |:Iipython|
 - julia   |:Ijulia|
 - maple   |:Imaple|
 - bash    |:Ibash|
 - zsh     |:Izsh|
-- python  |:Ipython| 
+- python  |:Ipython|
 - clojure |:Iclojure|
 - apl     |:Iclojure|
-- autodetect based on filetype |:Iterm| 
+- autodetect based on filetype |:Iterm|
 
 Commands may be sent from a text file to the chosen terminal using CTRL-S. If
 there is no terminal, CTRL-S will automatically open one for you using
@@ -47,7 +47,7 @@ interpreter. You can set it like this:
 
     let g:vimteractive_default_shells = { 'python': 'ipython' }
 
-Since this package leverages the native vim interactive terminal, it is 
+Since this package leverages the native vim interactive terminal, it is
 only compatible with vim 8 or greater.
 
 ==============================================================================
@@ -136,12 +136,12 @@ terminal.
 3. Common issues                                         *vimteractive-issues*
 
 ------------------------------------------------------------------------------
-Bracketed paste                          *vimteractive-issues-bracketed-paste* 
+Bracketed paste                          *vimteractive-issues-bracketed-paste*
 
 If you see strange symbols like ^[[200~ when sending lines to your new
 interpreter, you may be on an older system which does not have bracketed paste
 enabled, or have other shell misbehaviour issues. You can change the default
-setting with 
+setting with
 
     let g:vimteractive_bracketed_paste_default = 0
 

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -44,7 +44,7 @@ if !has_key(g:, 'vimteractive_default_shells')
 endif
 
 " If 0, disable bracketed paste escape sequences
-if !has_key(g:, 'vimteractive_bracketed_paste_default') 
+if !has_key(g:, 'vimteractive_bracketed_paste_default')
     let g:vimteractive_bracketed_paste_default=1
 endif
 if !has_key(g:, 'vimteractive_bracketed_paste')
@@ -77,7 +77,7 @@ if !has_key(g:, 'vimteractive_loaded')
 	command! -nargs=? -complete=customlist,vimteractive#buffer_list Iconn
 		\ :call vimteractive#connect(<f-args>)
 endif
-                    
+
 
 " Plugin key mappings
 " ===================


### PR DESCRIPTION
A nice one-liner that deletes all trailing whitespace on save:
`autocmd BufWritePre * %s/\s\+$//e`