### PR TITLE
Add option to change mode switching behaviour

### DIFF
--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -141,10 +141,12 @@ function! vimteractive#term_start(term_type)
 
     " Turn line numbering off
     set nonumber norelativenumber
-    " Switch to terminal-normal mode when entering buffer
-    autocmd BufEnter <buffer> call feedkeys("\<C-W>N")
-    " Switch to insert mode when leaving buffer
-    autocmd BufLeave <buffer> execute "silent! normal! i"
+    if g:vimteractive_switch_mode
+        " Switch to terminal-normal mode when entering buffer
+        autocmd BufEnter <buffer> call feedkeys("\<C-W>N")
+        " Switch to insert mode when leaving buffer
+        autocmd BufLeave <buffer> execute "silent! normal! i"
+    endif
     " Make :quit really do the right thing
     cabbrev <buffer> q bdelete! "
     cabbrev <buffer> qu bdelete! "

--- a/doc/vimteractive.txt
+++ b/doc/vimteractive.txt
@@ -153,6 +153,7 @@ These options can be put in your |.vimrc|, or run manually as desired:
 
     let g:vimteractive_vertical = 1        " Vertically split terminals
     let g:vimteractive_autostart = 0       " Don't start terminals by default
+    let g:vimteractive_switch_mode = 0     " Don't switch to normal mode
 
 
 ==============================================================================

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -19,6 +19,11 @@ if !has_key(g:, 'vimteractive_vertical')
     let g:vimteractive_vertical = 0
 endif
 
+" Switch to normal mode when entering the buffer by default
+if !has_key(g:, 'vimteractive_switch_mode')
+    let g:vimteractive_switch_mode = 1
+endif
+
 " Variables for running the various sessions
 if !has_key(g:, 'vimteractive_commands')
 	let g:vimteractive_commands = { }


### PR DESCRIPTION
I found the default behaviour somewhat cumbersome, as most of the times I found myself entering insert mode immediately after switching to the terminal buffer. This makes adds the option `g:vimteractive_switch_mode`, which can be set to 0 to turn off the automatic switch to normal mode.