### PR TITLE
Prevent automatic scroll on switching splits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Vimteractive
 ============
 :vimteractive: send commands from text files to interactive programs via vim
 :Author: Will Handley
-:Version: 2.3.1
+:Version: 2.4.0
 :Homepage: https://github.com/williamjameshandley/vimteractive
 :Documentation: ``:help vimteractive``
 

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -87,6 +87,11 @@ function! vimteractive#sendlines(lines)
 
     let l:term_type = getbufvar(b:vimteractive_connected_term, "vimteractive_term_type")
 
+    if stridx(term_getstatus(b:vimteractive_connected_term),"normal") != -1
+        execute ":b " . b:vimteractive_connected_term . "| silent! normal! i"
+        bprevious
+    endif
+
     if get(g:vimteractive_bracketed_paste, l:term_type, g:vimteractive_bracketed_paste_default)
         call term_sendkeys(b:vimteractive_connected_term,"[200~" . a:lines . "[201~\n")
     else
@@ -144,8 +149,6 @@ function! vimteractive#term_start(term_type)
     if g:vimteractive_switch_mode
         " Switch to terminal-normal mode when entering buffer
         autocmd BufEnter <buffer> call feedkeys("\<C-W>N")
-        " Switch to insert mode when leaving buffer
-        autocmd BufLeave <buffer> execute "silent! normal! i"
     endif
     " Make :quit really do the right thing
     cabbrev <buffer> q bdelete! "

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -87,8 +87,11 @@ function! vimteractive#sendlines(lines)
 
     let l:term_type = getbufvar(b:vimteractive_connected_term, "vimteractive_term_type")
 
-    if stridx(term_getstatus(b:vimteractive_connected_term),"normal") != -1
-        execute ":b " . b:vimteractive_connected_term . "| silent! normal! i"
+    " Switch to insert mode if the terminal is currently in normal mode
+    let l:term_status = term_getstatus(b:vimteractive_connected_term)
+    if stridx(l:term_status,"normal") != -1
+        execute ":b " . b:vimteractive_connected_term 
+        execute "silent! normal! i"
         bprevious
     endif
 


### PR DESCRIPTION
Resolves #31

Minor change to the behaviour. Instead of automatically switching to insert mode upon leaving a terminal buffer, the `vimteractive#sendlines` function now tests to see if it is in normal mode, and if so switches it back to insert mode in the same manner as was performed by the `BufLeave` command
