### PR TITLE
GPT terminal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Vimteractive
 ============
 :vimteractive: send commands from text files to interactive programs via vim
 :Author: Will Handley
-:Version: 2.6.0
+:Version: 2.7.0
 :Homepage: https://github.com/williamjameshandley/vimteractive
 :Documentation: ``:help vimteractive``
 

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ The activating commands are:
 - `apl <https://en.wikipedia.org/wiki/APL_(programming_language)>`__ ``:Iapl``
 - `R <https://www.r-project.org/>`__ ``:IR``
 - `sgpt <https://github.com/TheR1D/shell_gpt>`__ ``:Isgpt``
+- `gpt-command-line <https://github.com/kharvd/gpt-cli>`__ ``:Igpt``
 - autodetect based on filetype ``:Iterm``
 
 Commands may be sent from a text file to the chosen REPL using ``CTRL-S``.
@@ -155,6 +156,7 @@ Supported REPLs
 -  ``:Iapl`` Activate an apl REPL
 -  ``:IR`` Activate an R REPL
 -  ``:Isgpt`` Activate an sgpt REPL
+-  ``:Igpt`` Activate an gpt-command-line REPL
 -  ``:Iterm`` Activate default REPL for this filetype
 
 Sending commands
@@ -176,7 +178,7 @@ Retrieving command outputs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 CTRL-Y retrieves the output of the last command sent to the REPL. This only
-implemented in a subset of terminas (``:Iipython`` and ``:Isgpt``)
+implemented in a subset of terminas (``:Iipython``, ``:Isgpt`` and ``:Igpt``)
 
 In ``Normal-mode``, CTRL-Y retrieves the output of the last command sent to the
 REPL and places it in the current buffer.

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -249,6 +249,21 @@ function! vimteractive#get_response_sgpt()
     endif
 endfunction
 
+
+" Get the last response from the terminal for gpt-command-line
+function! vimteractive#get_response_gpt()
+    let l:logfile = s:vimteractive_logfiles[b:vimteractive_connected_term]
+    let log_data = readfile(l:logfile)
+    let log_data_str = join(log_data, "\n")
+
+    let last_session_index = strridx(log_data_str, 'gptcli-session - INFO - assistant: ')
+    let end_text = strpart(log_data_str, last_session_index+35)
+    let price_index = match(end_text, 'gptcli-price')
+    let last_price_index = strridx(end_text, "\n", price_index-1)
+    return strpart(end_text, 0, last_price_index)
+endfunction
+
+
 " Get the last response from the terminal for ipython
 function! vimteractive#get_response_ipython()
     let l:logfile = s:vimteractive_logfiles[b:vimteractive_connected_term]
@@ -270,10 +285,6 @@ endfunction
 function! vimteractive#next_term()
     let l:current_buffer = b:vimteractive_connected_term 
     let l:current_index = index(s:vimteractive_buffers, l:current_buffer)
-    if l:current_index == -1
-        echom "Not in a terminal buffer"
-        return
-    endif
     let l:next_index = (l:current_index + 1) % len(s:vimteractive_buffers)
     call vimteractive#connect(vimteractive#buffer_list()[l:next_index])
 endfunction
@@ -282,10 +293,6 @@ endfunction
 function! vimteractive#prev_term()
     let l:current_buffer = b:vimteractive_connected_term
     let l:current_index = index(s:vimteractive_buffers, l:current_buffer)
-    if l:current_index == -1
-        echom "Not in a terminal buffer"
-        return
-    endif
     let l:prev_index = (l:current_index - 1 + len(s:vimteractive_buffers)) % len(s:vimteractive_buffers)
     call vimteractive#connect(vimteractive#buffer_list()[l:prev_index])
 endfunction

--- a/doc/vimteractive.txt
+++ b/doc/vimteractive.txt
@@ -28,18 +28,19 @@ things like autocompletion, leaving that to other, more developed tools such as
 YouCompleteMe or GitHub copilot.
 
 The activating commands are
-- ipython       |:Iipython|
-- julia         |:Ijulia|
-- maple         |:Imaple|
-- mathematica   |:Imathematica|
-- bash          |:Ibash|
-- zsh           |:Izsh|
-- python        |:Ipython|
-- clojure       |:Iclojure|
-- apl           |:Iclojure|
-- R             |:IR|
-- mathematica   |:Imathematica|
-- sgpt          |:Isgpt|
+- ipython          |:Iipython|
+- julia            |:Ijulia|
+- maple            |:Imaple|
+- mathematica      |:Imathematica|
+- bash             |:Ibash|
+- zsh              |:Izsh|
+- python           |:Ipython|
+- clojure          |:Iclojure|
+- apl              |:Iclojure|
+- R                |:IR|
+- mathematica      |:Imathematica|
+- sgpt             |:Isgpt|
+- gpt-command-line |:Igpt|
 - autodetect based on filetype |:Iterm|
 
 Commands may be sent from a text file to the chosen REPL using CTRL-S. If
@@ -115,6 +116,7 @@ Supported terminals                                   *vimteractive-terminals*
 *:Iapl*         Activate an apl REPL
 *:IR*           Activate an R REPL
 *:Isgpt*        Activate an sgpt REPL
+*:Igpt*         Activate an gpt-command-line REPL
 *:Iterm*        Activate a REPL based on current filetype
 
 ------------------------------------------------------------------------------
@@ -139,7 +141,7 @@ create one for you using |:Iterm|.
 Retrieving command outputs                                          *v_CTRL_Y*
 
 CTRL-Y retrieves the output of the last command sent to the REPL. This only
-implemented in a subset of terminas (|:Iipython| and |:Isgpt|)
+implemented in a subset of REPLs (|:Iipython|, |:Isgpt| and |:Igpt|)
 
 In |Normal-mode|, CTRL-Y retrieves the output of the last command sent to the
 REPL and places it in the current buffer.

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -40,6 +40,7 @@ let g:vimteractive_commands.apl = 'apl'
 let g:vimteractive_commands.R = 'R'
 let g:vimteractive_commands.mathematica = 'math'
 let g:vimteractive_commands.sgpt = 'sgpt --repl <LOGFILE>'
+let g:vimteractive_commands.gpt = 'gpt --log_file <LOGFILE>'
 
 " Override default shells for different filetypes
 if !has_key(g:, 'vimteractive_default_shells')
@@ -68,7 +69,8 @@ let g:vimteractive_slow_prompt.clojure = 200
 
 let g:vimteractive_get_response = {
             \ 'ipython': function('vimteractive#get_response_ipython'),
-            \ 'sgpt': function('vimteractive#get_response_sgpt')
+            \ 'sgpt': function('vimteractive#get_response_sgpt'),
+            \ 'gpt': function('vimteractive#get_response_gpt')
             \}
 
 " Plugin commands


### PR DESCRIPTION
Adding [gpt-command-line](https://github.com/kharvd/gpt-cli) terminal in the same manner as sgpt. This alternative terminal offers more models, and yaml level configuration.

