### PR TITLE
Fix for failure in bracketed paste in gpt modules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Vimteractive
 ============
 :vimteractive: send commands from text files to interactive programs via vim
 :Author: Will Handley
-:Version: 2.7.0
+:Version: 2.7.1
 :Homepage: https://github.com/williamjameshandley/vimteractive
 :Documentation: ``:help vimteractive``
 

--- a/autoload/vimteractive.vim
+++ b/autoload/vimteractive.vim
@@ -103,11 +103,19 @@ function! vimteractive#sendlines(lines)
         execute ":b " . l:current_buffer
     endif
 
-    if get(g:vimteractive_bracketed_paste, l:term_type, g:vimteractive_bracketed_paste_default)
-        call term_sendkeys(b:vimteractive_connected_term,"[200~" . a:lines . "[201~\n")
+    if match(a:lines, '\n') >= 0
+        if has_key(g:vimteractive_brackets, l:term_type)
+            let open_bracket = g:vimteractive_brackets[l:term_type][0]
+            let close_bracket = g:vimteractive_brackets[l:term_type][1]
+        else
+            let open_bracket = g:open_bracketed_paste
+            let close_bracket = g:close_bracketed_paste
+        endif
+        let b:lines = open_bracket . a:lines . close_bracket . "\<Enter>"
     else
-        call term_sendkeys(b:vimteractive_connected_term, a:lines . "\n")
+        let b:lines = a:lines . "\<Enter>"
     endif
+    call term_sendkeys(b:vimteractive_connected_term, b:lines)
 endfunction
 
 " Start a vimteractive terminal

--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -28,38 +28,37 @@ endif
 if !has_key(g:, 'vimteractive_commands')
 	let g:vimteractive_commands = { }
 endif
+if !has_key(g:, 'vimteractive_brackets')
+	let g:vimteractive_brackets = { }
+endif
+
+let g:open_bracketed_paste = "[200~"
+let g:close_bracketed_paste = "[201~"
+
 
 let g:vimteractive_commands.ipython = 'ipython --matplotlib --no-autoindent --logfile="-o <LOGFILE>"'
 let g:vimteractive_commands.python = 'python'
+let g:vimteractive_brackets.python = ['','']
 let g:vimteractive_commands.bash = 'bash'
 let g:vimteractive_commands.zsh = 'zsh'
 let g:vimteractive_commands.julia = 'julia'
 let g:vimteractive_commands.maple = 'maple -c "interface(errorcursor=false);"'
 let g:vimteractive_commands.clojure = 'clojure'
+let g:vimteractive_brackets.clojure = ['','']
 let g:vimteractive_commands.apl = 'apl'
+let g:vimteractive_brackets.apl = ['','']
 let g:vimteractive_commands.R = 'R'
 let g:vimteractive_commands.mathematica = 'math'
+let g:vimteractive_brackets.mathematica = ['','']
 let g:vimteractive_commands.sgpt = 'sgpt --repl <LOGFILE>'
+let g:vimteractive_brackets.sgpt = ["\"\"\"\<Enter>" . g:open_bracketed_paste, g:close_bracketed_paste . "\<Enter>\"\"\""]
 let g:vimteractive_commands.gpt = 'gpt --log_file <LOGFILE>'
+let g:vimteractive_brackets.gpt = ["\\\<Enter>" . g:open_bracketed_paste, g:close_bracketed_paste . "\<Esc>\<Enter>"]
 
 " Override default shells for different filetypes
 if !has_key(g:, 'vimteractive_default_shells')
 	let g:vimteractive_default_shells = { }
 endif
-
-" If 0, disable bracketed paste escape sequences
-if !has_key(g:, 'vimteractive_bracketed_paste_default')
-    let g:vimteractive_bracketed_paste_default=1
-endif
-if !has_key(g:, 'vimteractive_bracketed_paste')
-	let g:vimteractive_bracketed_paste = { }
-endif
-let g:vimteractive_bracketed_paste.clojure = 0
-let g:vimteractive_bracketed_paste.python = 0
-let g:vimteractive_bracketed_paste.python2 = 0
-let g:vimteractive_bracketed_paste.python3 = 0
-let g:vimteractive_bracketed_paste.apl = 0
-let g:vimteractive_bracketed_paste.mathematica = 0
 
 " If present, wait this amount of time in ms when starting term on ^S
 if !has_key(g:, 'vimteractive_slow_prompt')


### PR DESCRIPTION
Moderate usage of gpt #38 and sgpt #37 have revealed a pasting bug for long prompts.

This does not occur for ipython, so this is an interaction between the REPL implementations of at least gpt and sgpt and vim terminal.

For a long prompt, the first roughly 30 lines are pasted correctly, but then lines after that are fed into the interpreter one at a time.

My suspicion is that this is associated with the buffering of [vim](https://github.com/vim/vim/blob/947f752a47b107529b5d591e4e24b51237c20497/src/channel.c#L4238) and the REPL terminal implementations.

One solution, proposed here, to use additional start and end bracketing text, forcing the REPL to enter multiline mode, which extends (if necessary) the bracketed paste.
